### PR TITLE
Store separate Verify-Directories

### DIFF
--- a/empty-saved-dir.json
+++ b/empty-saved-dir.json
@@ -1,3 +1,4 @@
 {
-  "savedDir": null
+  "helloWorld": null,
+  "patchwork": null
 }

--- a/lib/challenge-verify-handler.js
+++ b/lib/challenge-verify-handler.js
@@ -50,11 +50,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Only if button exists
   if (selectDirButton) {
-    let savedDir = userData.getSavedDir().savedDir
-    // On 'forks_and_clones', clear savedDir as it should change.
-    if (currentChallenge === 'forks_and_clones') {
-      savedDir = null
-    }
+    const savedDir = userData.getSavedDir(currentChallenge)
+
     if (!savedDir) {
       showSelectedDirDiv(false)
     } else {
@@ -70,7 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
 ipc.on('confirm-selectDir', (event, path) => {
   selectedDirPath.innerText = path
   showSelectedDirDiv(true)
-  userData.updateSavedDir(path)
+  userData.updateSavedDir(currentChallenge, path)
 })
 
 /*

--- a/lib/user-data.js
+++ b/lib/user-data.js
@@ -11,41 +11,58 @@ const userDataPath = ipc.sendSync('getUserDataPath')
 const userDataFile = path.join(userDataPath, 'user-data.json')
 const savedDirFile = path.join(userDataPath, 'saved-dir.json')
 
+// Map challenge verify-directories
+const verifyDir = {
+  repository: 'helloWorld',
+  commit_to_it: 'helloWorld',
+  remote_control: 'helloWorld',
+  forks_and_clones: 'patchwork',
+  branches_arent_just_for_birds: 'patchwork',
+  pull_never_out_of_date: 'patchwork',
+  merge_tada: 'patchwork'
+}
+
 /****
  * user-data.json
  */
 // Returns either an object out of all challengesData-objects or if called with parameter the object to the given challenge.
 function getChallengeData (challenge = null) {
+  const fileContent = JSON.parse(fs.readFileSync(userDataFile))
   if (challenge) {
-    return JSON.parse(fs.readFileSync(userDataFile))[challenge]
+    return fileContent[challenge]
   }
-  return JSON.parse(fs.readFileSync(userDataFile))
+  return fileContent
 }
 // Set given challenge completed-status
 function setChallengeCompleted (challenge, completed) {
-  const data = getChallengeData()
-  data[challenge].completed = completed
-  writeData(userDataFile, data)
+  const fileContent = getChallengeData()
+  fileContent[challenge].completed = completed
+  writeData(userDataFile, fileContent)
 }
 // Clear all challenges - Set all challenges as incomplete
 function clearAllChallenges () {
-  const data = getChallengeData()
-  Object.keys(data).forEach(challenge => {
-    data[challenge].completed = false
+  const fileContent = getChallengeData()
+  Object.keys(fileContent).forEach(challenge => {
+    fileContent[challenge].completed = false
   })
-  writeData(userDataFile, data)
+  writeData(userDataFile, fileContent)
 }
 
 /****
  * saved-dir.json
  */
-function getSavedDir () {
-  return JSON.parse(fs.readFileSync(savedDirFile))
+function getSavedDir (currentChallenge = null) {
+  const fileContent = JSON.parse(fs.readFileSync(savedDirFile))
+  if (currentChallenge) {
+    return fileContent[verifyDir[currentChallenge]]
+  }
+  return fileContent
 }
-function updateSavedDir (path) {
-  const data = getSavedDir()
-  data.savedDir = path
-  writeData(savedDirFile, data)
+// Store directory
+function updateSavedDir (currentChallenge, path) {
+  const fileContent = getSavedDir()
+  fileContent[verifyDir[currentChallenge]] = path
+  writeData(savedDirFile, fileContent)
 }
 
 /****


### PR DESCRIPTION
Store both verify-directories, so the will be shown again right, when switching between challenges.

Closes #85 