### PR TITLE
Fix rtl languages

### DIFF
--- a/assets/css/new-challenge.css
+++ b/assets/css/new-challenge.css
@@ -177,6 +177,11 @@ gre7-border.border-box code {
 
 /* CODE STYLES
    -------------------------------------------------------------------------- */
+   /* TODO needs some Cleanup, to have similar styling accros challenges and no doubled classes here! */
+
+div.code {
+  padding-bottom: 4px;
+}
 
 code {
   font-size: 0.8em;

--- a/config/i18next.config.js
+++ b/config/i18next.config.js
@@ -1,18 +1,22 @@
 /** Configuration Settings for i18next */
 
-// Available appLanguages
+/* Available appLanguages
+ * Each language is defined as an object per languageKey:
+ * The Object MUST contain a name-property, which will be shown in the dropdown-menu
+ * Optional Property "direction: 'rtl'" is used to mark right-to-left lanugages.
+ */
 const appLanguages = {
-  'en-US': 'English',
-  'de-DE': 'Deutsch',
-  'es-ES': 'Español',
-  'fr-FR': 'Français',
-  'ja-JP': '日本語',
-  'ko-KR': '한국어',
-  'ku': 'کوردی',
-  'pl-PL': 'Polski',
-  'pt-BR': 'Português Brasileiro',
-  'uk-UA': 'Українська',
-  'zh-TW': '中文(臺灣)',
+  'en-US': { name: 'English' },
+  'de-DE': { name: 'Deutsch' },
+  'es-ES': { name: 'Español' },
+  'fr-FR': { name: 'Français' },
+  'ja-JP': { name: '日本語' },
+  'ko-KR': { name: '한국어' },
+  'ku':    { name: 'کوردی', direction: 'rtl' },
+  'pl-PL': { name: 'Polski' },
+  'pt-BR': { name: 'Português Brasileiro' },
+  'uk-UA': { name: 'Українська' },
+  'zh-TW': { name: '中文(臺灣)' },
 }
 const appLanguageKeys = Object.keys(appLanguages)
 

--- a/lib/build/build-helpers.js
+++ b/lib/build/build-helpers.js
@@ -11,8 +11,8 @@ function getLocaleMenu () {
   const { appLanguages } = require('../../config/i18next.config')
   let localeMenu = ''
 
-  Object.entries(appLanguages).forEach(([languageKey, language]) => {
-    localeMenu = localeMenu.concat('<option value="' + languageKey + '">' + language + '</option>')
+  Object.entries(appLanguages).forEach(([languageKey, languageObject]) => {
+    localeMenu = localeMenu.concat('<option value="' + languageKey + '">' + languageObject.name + '</option>')
   })
   return localeMenu
 }

--- a/lib/i18n-translate.js
+++ b/lib/i18n-translate.js
@@ -103,6 +103,8 @@ function insertBoxTranslationStyles () {
   // Insert Style for right-to-left languages
   if (appLanguages[i18n.language].direction === 'rtl') {
     document.styleSheets[sheetIndex].insertRule('div.content {direction: rtl;}')
+    // Code-Elements should stay ltr
+    document.styleSheets[sheetIndex].insertRule('div.code {direction: ltr;}')
   }
 
   // Append rules for challenge-boxes

--- a/lib/i18n-translate.js
+++ b/lib/i18n-translate.js
@@ -8,6 +8,7 @@
  */
 
 const i18n = require('electron').remote.getGlobal('i18n')
+const { appLanguages } = require('../config/i18next.config')
 
 // defaultOptions for interpolation
 const defaultOptions = {
@@ -99,9 +100,16 @@ function insertBoxTranslationStyles () {
     document.styleSheets[sheetIndex].deleteRule(0)
   }
 
-  // Append new rules
-  document.styleSheets[sheetIndex].insertRule(".chal-goal.border-box::before {content: '" + i18n.t('Goal') + "';}", 0)
-  document.styleSheets[sheetIndex].insertRule(".chal-no-pass.border-box::before {content: '" + i18n.t("Didn't Pass?") + "';}", 0)
-  document.styleSheets[sheetIndex].insertRule(".chal-tip.border-box::before {content: '" + i18n.t('Tip') + "';}", 0)
-  document.styleSheets[sheetIndex].insertRule(".chal-step.border-box::before {content: '" + i18n.t('Step') + "';}", 0)
+  // Insert Style for right-to-left languages
+  if (appLanguages[i18n.language].direction === 'rtl') {
+    document.styleSheets[sheetIndex].insertRule('div.content {direction: rtl;}')
+  }
+
+  // Append rules for challenge-boxes
+  if (document.styleSheets[sheetIndex].ownerNode.id === 'challenge-translation-style') {
+    document.styleSheets[sheetIndex].insertRule(".chal-goal.border-box::before {content: '" + i18n.t('Goal') + "';}")
+    document.styleSheets[sheetIndex].insertRule(".chal-no-pass.border-box::before {content: '" + i18n.t("Didn't Pass?") + "';}")
+    document.styleSheets[sheetIndex].insertRule(".chal-tip.border-box::before {content: '" + i18n.t('Tip') + "';}")
+    document.styleSheets[sheetIndex].insertRule(".chal-step.border-box::before {content: '" + i18n.t('Step') + "';}")
+  }
 }

--- a/resources/content/challenges/11_merge_tada.hbs
+++ b/resources/content/challenges/11_merge_tada.hbs
@@ -13,16 +13,16 @@
     <p i18n-data="ch11~Your pull request has been merged! Your branch was merged into the 'gh-pages' branch of the original on GitHub. You can merge your branch locally, too."></p>
 
     <p i18n-data="ch11~First, move into the branch you want to merge into — in this case, the branch 'gh-pages'."></p>
-    <p><code class="shell">git checkout gh-pages</code></p>
+    <div class='code'><code class="shell">git checkout gh-pages</code></div>
 
     <p i18n-data="ch11~Now tell Git what branch you want to merge in — in this case, your feature branch that begins with {/dqm/}add-{/dqm/}."></p>
-    <p><code class="shell">git merge &#60;BRANCHNAME&#62;</code></p>
+    <div class='code'><code class="shell">git merge &#60;BRANCHNAME&#62;</code></div>
 
     <p i18n-data="ch11~Tidy up by deleting your feature branch. Now that it has been merged you don't really need it around."></p>
-    <p><code class="shell">git branch -d &#60;BRANCHNAME&#62;</code></p>
+    <div class='code'><code class="shell">git branch -d &#60;BRANCHNAME&#62;</code></div>
 
     <p i18n-data="ch11~You can also delete the branch from your remote on GitHub:"></p>
-    <p><code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></p>
+    <div class='code'><code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></div>
 </div>
 
 <div class="chal-step blue-border border-box">
@@ -30,7 +30,7 @@
     <p i18n-data="ch11~And last but not least, the original has changed since your pull request was merged — Reporobot added your name to the website! If you pull in these changes from upstream you'll be up to date and have that version too. You can actually see it live as well at: yourusername.github.io/patchwork."></p>
 
     <p i18n-data="ch11~To pull from the original upstream:"></p>
-    <p><code class="shell">git pull upstream gh-pages</code></p>
+    <div class='code'><code class="shell">git pull upstream gh-pages</code></div>
 </div>
 
 <div class="chal-background light-blue solid-box">
@@ -50,14 +50,14 @@
 <div class="chal-tip grey-border border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="ch11~Merge a branch into current branch"></strong></li>
-        <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git merge &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="ch11~Change the branch you're working on"></strong></li>
-        <code class="shell">git checkout &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="ch11~Delete a local branch"></strong></li>
-        <code class="shell">git branch -d &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git branch -d &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="ch11~Delete a remote branch"></strong></li>
-        <code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="ch11~Pull from a remote branch"></strong></li>
-        <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code></div>
     </ul>
 </div>

--- a/resources/content/challenges/1_get_git.hbs
+++ b/resources/content/challenges/1_get_git.hbs
@@ -48,17 +48,17 @@
     <p i18n-type="standard_html"
         i18n-data="ch01~Once Git is installed, open your {/str/}terminal{/str_e/}. You can verify that Git is really there by typing:"></p>
 
-    <p><code class="shell">git --version</code></p>
+    <div class='code'><code class="shell">git --version</code></div>
 
     <p i18n-data="ch01~This will return the version of Git on your computer and look something like this:"></p>
 
-    <p><code class="comment">git version 1.9.1</code></p>
+    <div class='code'><code class="comment">git version 1.9.1</code></div>
 
     <p i18n-data="ch01~Next, configure Git so it knows to associate your work to you:"></p>
     <p i18n-data="ch01~Set your name:"></p>
-    <p><code class="shell">git config --global user.name "Your Name"</code></p>
+    <div class='code'><code class="shell">git config --global user.name "Your Name"</code></div>
     <p i18n-data="ch01~Now set your email:"></p>
-    <p><code class="shell">git config --global user.email "youremail@example.com"</code></p>
+    <div class='code'><code class="shell">git config --global user.email "youremail@example.com"</code></div>
 
     <p i18n-data="ch01~You're done with your first challenge! Click the 'Verify' button to check the challenge."></p>
 </div>

--- a/resources/content/challenges/2_repository.hbs
+++ b/resources/content/challenges/2_repository.hbs
@@ -37,14 +37,14 @@
 
     <p><span i18n-data="ch02~First, make a new folder:"></span></br>
         <span class="inline-tip" i18n-type="standard_html" i18n-data="ch02~Tip: mkdir stands for {/em/}make directory{/em_e/}"></span></p>
-    <code class="shell">mkdir hello-world</code>
+    <div class='code'><code class="shell">mkdir hello-world</code></div>
 
     <p><span i18n-data="ch02~Then go into that folder:"></span></br>
         <span class="inline-tip" i18n-type="standard_html" i18n-data="ch02~Tip: cd stands for {/em/}change directory{/em_e/}"></span></p>
-    <code class="shell">cd hello-world</code>
+    <div class='code'><code class="shell">cd hello-world</code></div>
 
     <p i18n-data="ch02~Finally, tell Git to initialize (start tracking) the folder you are now in:"></p>
-    <code class="shell">git init</code>
+    <div class='code'><code class="shell">git init</code></div>
 
     <p i18n-data="ch02~The last command should return something starting with 'Initialized empty Git repository'. The others commands do not return anything."></p>
 
@@ -57,12 +57,12 @@
 <div class="chal-tip grey-border border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="ch02~Make a new folder (aka make directory)"></strong></li>
-        <code class="shell">mkdir &#60;FOLDERNAME&#62;</code>
+        <div class='code'><code class="shell">mkdir &#60;FOLDERNAME&#62;</code></div>
         <li><strong i18n-data="ch02~Navigate into an existing folder (aka change directory)"></strong></li>
-        <code class="shell">cd &#60;FOLDERNAME&#62;</code>
+        <div class='code'><code class="shell">cd &#60;FOLDERNAME&#62;</code></div>
         <li><strong i18n-data="ch02~List the items in a folder"></strong></li>
-        <code class="shell">ls </code>
+        <div class='code'><code class="shell">ls </code></div>
         <li><strong i18n-data="ch02~Turn Git on for a folder"></strong></li>
-        <code class="shell">git init</code>
+        <div class='code'><code class="shell">git init</code></div>
     </ul>
 </div>

--- a/resources/content/challenges/3_commit_to_it.hbs
+++ b/resources/content/challenges/3_commit_to_it.hbs
@@ -21,16 +21,16 @@
     <p i18n-data="ch03~Make sure you're still within your 'hello-world' directory when you're running these commands. Use Git to see what changed in your repository:"></p>
 
     <p i18n-data="ch03~First, check the status:"></p>
-    <p><code class="shell">git status</code></p>
+    <div class='code'><code class="shell">git status</code></div>
     <p i18n-data="ch03~Git should tell you that a file has been added."></p>
 
     <p i18n-type="standard_html"
         i18n-data="ch03~Then {/str/}add{/str_e/} the file you just created so that it becomes a part of the changes you will {/str/}commit{/str_e/} (aka save) with Git:"></p>
-    <p><code class="shell">git add readme.txt</code></p>
+    <div class='code'><code class="shell">git add readme.txt</code></div>
 
     <p i18n-type="standard_html"
         i18n-data="ch03~Finally, {/str/}commit{/str_e/} those changes to the repository's history with a short (m) message describing the updates."></p>
-    <p><code class="shell">git commit -m "Created readme"</code></p>
+    <div class='code'><code class="shell">git commit -m "Created readme"</code></div>
 </div>
 
 <div class="chal-step blue-border border-box">
@@ -42,7 +42,7 @@
 
     <p i18n-type="standard_html"
         i18n-data="ch03~Tell Git to show you the {/str/}diff{/str_e/}:"></p>
-    <p><code class="shell">git diff</code></p>
+    <div class='code'><code class="shell">git diff</code></div>
 
     <p i18n-data="ch03~Now with what you just learned above, commit this latest change."></p>
 </div>
@@ -52,14 +52,14 @@
 <div class="chal-tip grey-border border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="ch03~Check status of changes to a repository"></strong></li>
-        <li><code class="shell">git status</code></li>
+        <div class='code'><code class="shell">git status</code></div>
         <li><strong i18n-data="ch03~View changes to files"></strong></li>
-        <li><code class="shell">git diff</code></li>
+        <div class='code'><code class="shell">git diff</code></div>
         <li><strong i18n-data="ch03~Add a file's changes to be committed"></strong></li>
-        <li><code class="shell">git add &#60;FILENAME&#62;</code></li>
+        <div class='code'><code class="shell">git add &#60;FILENAME&#62;</code></div>
         <li><strong i18n-data="ch03~To add all files changes"></strong></li>
-        <li><code class="shell">git add .</code></li>
+        <div class='code'><code class="shell">git add .</code></div>
         <li><strong i18n-data="ch03~To commit (aka save) the changes you've added with a short message describing the changes"></strong></li>
-        <li><code class="shell">git commit -m "your commit message"</code></li>
+        <div class='code'><code class="shell">git commit -m "your commit message"</code></div>
         <ul>
 </div>

--- a/resources/content/challenges/4_githubbin.hbs
+++ b/resources/content/challenges/4_githubbin.hbs
@@ -26,10 +26,10 @@
         i18n-data="ch04~Add your GitHub username to your Git configuration. We'll do this just for the sake of Git-it{/smc/} it makes it easier to verify the upcoming challenges. Save it exactly as you created it on GitHub and {/str/}capitalize where capitalized{/str_e/}. Note, you don't need to enter the {/dqm/}{/lt/}{/dqm/} and {/dqm/}{/gt/}{/dqm/}."></p>
 
     <p i18n-data="ch04~Add your GitHub username to your Git configuration:"></p>
-    <code class="shell">git config --global user.username &#60;UserName&#62;</code>
+    <div class='code'><code class="shell">git config --global user.username &#60;UserName&#62;</code></div>
 
     <p i18n-data="ch04~You can double check what you have set in your Git config by typing:"></p>
-    <code>git config --global user.username</code>
+    <div class='code'><code>git config --global user.username</code></div>
 </div>
 
 {{{ verify_button }}}
@@ -44,6 +44,6 @@
 
     <p i18n-type="standard_html" i18n-data="ch04~A common error is not having your GitHub username match the case of the one you set with {/cde/}git config{/cde_e/}. For instance, 'JLord' isn't the same as 'jlord'"></p>
     <p i18n-data="ch04~To change your username set with Git, just do the same command you did earlier, but with the correct capitalization:"></p>
-    <p><code class="shell">git config --global user.username &#60;UserName&#62;</code></p>
+    <div class='code'><code class="shell">git config --global user.username &#60;UserName&#62;</code></div>
     <p i18n-data="ch04~When you've made your updates, verify again!"></p>
 </div>

--- a/resources/content/challenges/5_remote_control.hbs
+++ b/resources/content/challenges/5_remote_control.hbs
@@ -57,7 +57,7 @@
         i18n-data="ch05~Back in your terminal, and inside of the 'hello-world' folder that you initialized as a Git repository in the earlier challenge, you want to tell Git to remember the address of the remote version on GitHub's servers. You can have multiple remotes so each requires a name. The primary remote is typically named {/cde/}origin{/cde_e/}."></p>
 
     <p i18n-data="ch05~To add a remote named 'origin' to your repository:"></p>
-    <code class="shell">git remote add origin &lt;URLFROMGITHUB&gt;</code>
+    <div class='code'><code class="shell">git remote add origin &lt;URLFROMGITHUB&gt;</code></div>
 
     <p i18n-type="standard_html"
         i18n-data="ch05~Your {/str/}local{/str_e/} repository now knows where your {/str/}remote{/str_e/} repository, named 'origin', lives on GitHub's servers. Think of it as adding a name and address on speed dial—now when you need to send something there, you can."></p>
@@ -67,7 +67,7 @@
         <p i18n-type="standard_html"
             i18n-data="ch05~If you have {/str/}GitHub Desktop{/str_e/} on your computer, a remote named 'origin' is automatically created in your local repository. In that case, you'll just need to tell it what URL to associate with 'origin'. Use this command instead of the 'add' one above:"></p>
 
-        <code class="shell">git remote set-url origin &lt;URLFROMGITHUB&gt;</code>
+        <div class='code'><code class="shell">git remote set-url origin &lt;URLFROMGITHUB&gt;</code></div>
     </blockquote>
 </div>
 
@@ -80,7 +80,7 @@
         i18n-data="ch05~Git has a branching system so that you can work on different parts of a project at different times. We'll learn more about that later, but by default the first branch is named 'master'. When you push (and later pull) from a project, you tell Git the {/str/}branch name{/str_e/} you want and the name of the {/str/}remote{/str_e/} that it lives on."></p>
 
     <p i18n-data="ch05~In this case, we'll send our branch named 'master' to our remote on GitHub named 'origin'."></p>
-    <code class="shell">git push origin master</code>
+    <div class='code'><code class="shell">git push origin master</code></div>
 
     <p i18n-type="standard_html"
         i18n-data="ch05~Now go to your remote repository's page on GitHub.com and refresh the page. {/str/}Wow!{/str_e/} Everything is now the same locally as it is remotely. Congrats on your first public repository!"></p>
@@ -91,14 +91,14 @@
 <div class="chal-tip grey-border border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="ch05~Add remote connections"></strong></li>
-        <code class="shell">git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code>
+        <div class='code'><code class="shell">git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code></div>
         <li><strong i18n-data="ch05~Set a URL to a remote"></strong></li>
-        <code class="shell">git remote set-url &lt;REMOTENAME&gt; &lt;URL&gt;</code>
+        <div class='code'><code class="shell">git remote set-url &lt;REMOTENAME&gt; &lt;URL&gt;</code></div>
         <li><strong i18n-data="ch05~Pull in changes"></strong></li>
-        <code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
+        <div class='code'><code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></div>
         <li><strong i18n-data="ch05~View remote addresses"></strong></li>
-        <code class="shell">git remote -v</code>
+        <div class='code'><code class="shell">git remote -v</code></div>
         <li><strong i18n-data="ch05~Push changes"></strong></li>
-        <code class="shell">git push &lt;REMOTENAME&gt; &lt;BRANCH&gt;</code>
+        <div class='code'><code class="shell">git push &lt;REMOTENAME&gt; &lt;BRANCH&gt;</code></div>
     </ul>
 </div>

--- a/resources/content/challenges/6_forks_and_clones.hbs
+++ b/resources/content/challenges/6_forks_and_clones.hbs
@@ -36,13 +36,13 @@
     <p><span i18n-data="ch06~Back out of your 'hello-world' folder:"></span></br>
         <span class="inline-tip" i18n-data="ch06~Tip: the two dots mean step out of a directory one level"></span>
     </p>
-    <p><code class="shell">cd ..</code></p>
+    <div class='code'><code class="shell">cd ..</code></div>
 
     <p i18n-data="ch06~Now that you're no longer in another Git repository, clone your fork:"></p>
-    <p><code class="shell">git clone &#60;URLFROMGITHUB&#62;</code></p>
+    <div class='code'><code class="shell">git clone &#60;URLFROMGITHUB&#62;</code></div>
 
     <p i18n-data="ch06~Go into the folder it created for your local copy of the fork (in this case, named 'patchwork')."></p>
-    <p><code class="shell">cd patchwork</code></p>
+    <div class='code'><code class="shell">cd patchwork</code></div>
 
     <p i18n-type="standard_html"
         i18n-data="ch06~Now you've got a copy of the repository on your computer and it is automatically connected to the remote repository (your forked copy) on your GitHub account. Type {/cde/}git remote -v{/cde_e/} to see that the address to the fork is already set up."></p>
@@ -59,7 +59,7 @@
 
     <p i18n-data="ch06~You can name this remote connection anything you want, but typically people use the name 'upstream'{/smc/} let's use that for this."></p>
 
-    <p><code class="shell">git remote add upstream https://github.com/jlord/patchwork.git</code></p>
+    <div class='code'><code class="shell">git remote add upstream https://github.com/jlord/patchwork.git</code></div>
 
     <p i18n-type="standard_html"
         i18n-data="ch06~To be sure you have the correct remotes set up, type {/cde/}git remote -v{/cde_e/} to list out the addresses you have stored. {/str/}You should have an 'origin' remote with your fork's address and then an 'upstream' remote with the address to the original, the URL noted above in this step.{/str_e/}"></p>
@@ -70,10 +70,10 @@
 <div class="chal-tip grey-border border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="ch06~Add a remote"></strong></li>
-        <li><code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
+        <div class='code'><code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></div>
         <li><strong i18n-data="ch06~Change a remote URL"></strong></li>
-        <li><code class="shell">git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
+        <div class='code'><code class="shell">git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code></div>
         <li><strong i18n-data="ch06~View remote connections"></strong></li>
-        <li><code class="shell">git remote -v</code></li>
+        <div class='code'><code class="shell">git remote -v</code></div>
     </ul>
 </div>

--- a/resources/content/challenges/7_branches_arent_just_for_birds.hbs
+++ b/resources/content/challenges/7_branches_arent_just_for_birds.hbs
@@ -26,7 +26,7 @@
             "lnk_pages": "http://pages.github.com"
         }'></p>
 
-    <code>http://githubusername.github.io/repositoryname</code>
+    <div class='code'><code>http://githubusername.github.io/repositoryname</code></div>
 </div>
 
 <div class="chal-step blue-border border-box">
@@ -43,14 +43,14 @@
             "add_jlord": "{/dqm/}add-jlord{/dqm/}"
         }'></p>
 
-    <p><code class="shell">git branch &#60;BRANCHNAME&#62;</code></p>
+    <div class='code'><code class="shell">git branch &#60;BRANCHNAME&#62;</code></div>
 
     <p i18n-data="ch07~Now you have a branch with a new name that is identical to 'gh-pages'."></p>
 
     <p i18n-type="standard_html"
         i18n-data="ch07~To go into that branch and work on it you {/str/}checkout{/str_e/} a branch. Go on your new branch:"></p>
 
-    <p><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></p>
+    <div class='code'><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></div>
 </div>
 
 <div class="chal-step blue-border border-box">
@@ -76,13 +76,13 @@
     <h3 i18n-data="ch07~Check-in"></h3>
     <p i18n-data="ch07~Go through the steps for checking in a project: "></p>
 
-    <p><code class="shell">git status</code></p>
-    <p><code class="shell">git add &#60;contributors/FILENAME&#62;</code></p>
-    <p><code class="shell">git commit -m "commit message"</code></p>
+    <div class='code'><code class="shell">git status</code></div>
+    <div class='code'><code class="shell">git add &#60;contributors/FILENAME&#62;</code></div>
+    <div class='code'><code class="shell">git commit -m "commit message"</code></div>
 
     <p i18n-type="standard_html"
         i18n-data="ch07~Now push your update to {/str/}your fork{/str_e/}, 'origin', on GitHub:"></p>
-    <p><code class="shell">git push origin &#60;BRANCHNAME&#62;</code></p>
+    <div class='code'><code class="shell">git push origin &#60;BRANCHNAME&#62;</code></div>
 </div>
 
 {{{ verify_directory_button }}}
@@ -106,28 +106,28 @@
     <h4 i18n-data="ch07~File NOT in contributors folder"></h4>
     <p i18n-type="standard_html"
         i18n-data="ch07~The file you create should be placed inside the existing 'contributors' folder in the Patchwork repository. If you put it somewhere else, simply use Finder or Windows Explorer to move your file into the folder. You can check {/cde/}git status{/cde_e/} again and you'll find it sees your changes. Stage and then commit all of these changes (additions and deletions) with the commands below."></p>
-    <p><code class="shell">git add -A</code></p>
-    <p><code class="shell">git commit -m "move file into contributors folder"</code></p>
+    <div class='code'><code class="shell">git add -A</code></div>
+    <div class='code'><code class="shell">git commit -m "move file into contributors folder"</code></div>
 
     <h4 i18n-data="ch07~Branch name expected: _____"></h4>
     <p i18n-data="ch07~The branch name should match your user name exactly. To change your branch name:"></p>
-    <p><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></p>
+    <div class='code'><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></div>
     <p i18n-data="ch07~When you've made your updates, verify again!"></p>
 </div>
 
 <div class="chal-tip grey-border border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="ch07~You can create and switch to a branch in one line"></strong></li>
-        <li><code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code></li>
+        <div class='code'><code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="ch07~Create a new branch"></strong></li>
-        <li><code class="shell">git branch &#60;BRANCHNAME&#62;</code></li>
+        <div class='code'><code class="shell">git branch &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="ch07~Move onto a branch"></strong></li>
-        <li><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></li>
+        <div class='code'><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="ch07~List the branches"></strong></li>
-        <li><code class="shell">git branch</code></li>
+        <div class='code'><code class="shell">git branch</code></div>
         <li><strong i18n-data="ch07~Rename a branch you're currently on"></strong></li>
-        <li><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></li>
+        <div class='code'><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></div>
         <li><strong i18n-data="ch07~Verify what branch you're working on"></strong></li>
-        <li><code class="shell">git status</code></li>
+        <div class='code'><code class="shell">git status</code></div>
     </ul>
 </div>

--- a/resources/content/challenges/8_its_a_small_world.hbs
+++ b/resources/content/challenges/8_its_a_small_world.hbs
@@ -25,7 +25,7 @@
     <p i18n-type="standard_html"
         i18n-data="ch08~{/str/}Now go to your forked Patchwork repository's page on GitHub and add 'RepoRobot' as a collaborator.{/str_e/} The URL should look like this, but with your own username."></p>
 
-    <code>https://github.com/YOURUSERNAME/patchwork/settings/access</code>
+    <div class='code'><code>https://github.com/YOURUSERNAME/patchwork/settings/access</code></div>
 </div>
 
 {{{ verify_button }}}

--- a/resources/content/challenges/9_pull_never_out_of_date.hbs
+++ b/resources/content/challenges/9_pull_never_out_of_date.hbs
@@ -15,7 +15,7 @@
     <h3 i18n-data="ch09~What has Reporobot been up to?"></h3>
     <p i18n-data="ch09~See if Reporobot has made any changes to your branch by pulling in any changes from the remote named 'origin' on GitHub:"></p>
 
-    <p><code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></p>
+    <div class='code'><code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></div>
 
     <p i18n-data="ch09~If nothing's changed, it will tell you 'Already up-to-date'. If there are changes, Git will merge those changes into your local version."></p>
 
@@ -27,10 +27,10 @@
 <div class="chal-tip grey-border border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="ch09~Check Git status"></strong></li>
-        <code class="shell">git status</code>
+        <div class='code'><code class="shell">git status</code></div>
         <li><strong i18n-data="ch09~Pull in changes from a remote branch"></strong></li>
-        <code class="shell">git pull &lt;REMOTENAME&gt; &lt;REMOTEBRANCH&gt;</code>
+        <div class='code'><code class="shell">git pull &lt;REMOTENAME&gt; &lt;REMOTEBRANCH&gt;</code></div>
         <li><strong i18n-data="ch09~See changes to the remote before you pull in"></strong></li>
-        <code class="shell">git fetch --dry-run</code>
+        <div class='code'><code class="shell">git fetch --dry-run</code></div>
     </ul>
 </div>

--- a/resources/content/pages/dictionary.hbs
+++ b/resources/content/pages/dictionary.hbs
@@ -4,11 +4,11 @@
 <div class="blue-border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="dictionary~Make a new folder (aka make directory)"></strong></li>
-        <code class="shell">mkdir &#60;FOLDERNAME&#62;</code>
+        <div class='code'><code class="shell">mkdir &#60;FOLDERNAME&#62;</code></div>
         <li><strong i18n-data="dictionary~Navigate into an existing folder (aka 'change directory')"></strong></li>
-        <code class="shell">cd &#60;FOLDERNAME&#62;</code>
+        <div class='code'><code class="shell">cd &#60;FOLDERNAME&#62;</code></div>
         <li><strong i18n-data="dictionary~List the items in a folder"></strong></li>
-        <code class="shell">ls </code>
+        <div class='code'><code class="shell">ls </code></div>
     </ul>
 </div>
 
@@ -16,13 +16,13 @@
 <div class="blue-border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="dictionary~Check Git version"></strong></li>
-        <code>git --version</code>
+        <div class='code'><code>git --version</code></div>
         <li><strong i18n-data="dictionary~Set your name"></strong></li>
-        <code>git config --global user.name "Your Name"</code>
+        <div class='code'><code>git config --global user.name "Your Name"</code></div>
         <li><strong i18n-data="dictionary~Set your email"></strong></li>
-        <code>git config --global user.email youremail@example.com</code>
+        <div class='code'><code>git config --global user.email youremail@example.com</code></div>
         <li><strong i18n-data="dictionary~Set your Github account (case sensitive)"></strong></li>
-        <code>git config --global user.username uSeRnAmE</code>
+        <div class='code'><code>git config --global user.username uSeRnAmE</code></div>
     </ul>
 </div>
 
@@ -30,20 +30,20 @@
 <div class="blue-border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="dictionary~Turn Git on for a folder"></strong></li>
-        <code class="shell">git init</code>
+        <div class='code'><code class="shell">git init</code></div>
         <li><strong i18n-data="dictionary~Check status of changes to a repository"></strong></li>
-        <code class="shell">git status</code>
+        <div class='code'><code class="shell">git status</code></div>
         <li><strong i18n-data="dictionary~View changes to files"></strong></li>
-        <code class="shell">git diff</code>
+        <div class='code'><code class="shell">git diff</code></div>
         <li><strong i18n-data="dictionary~Add a file's changes to be committed"></strong></li>
-        <code class="shell">git add &#60;FILENAME&#62;</code>
+        <div class='code'><code class="shell">git add &#60;FILENAME&#62;</code></div>
         <li><strong i18n-data="dictionary~To add all files changes"></strong></li>
-        <code class="shell">git add .</code>
+        <div class='code'><code class="shell">git add .</code></div>
         <li><strong i18n-data="dictionary~To commit (aka save) the changes you've added with a short message describing the changes"></strong>
         </li>
-        <code class="shell">git commit -m "your commit message"</code>
+        <div class='code'><code class="shell">git commit -m "your commit message"</code></div>
         <li><strong i18n-data="dictionary~Copy a repository to your computer"></strong></li>
-        <code class="shell">git clone &#60;URL&#62;</code>
+        <div class='code'><code class="shell">git clone &#60;URL&#62;</code></div>
     </ul>
 </div>
 
@@ -51,15 +51,15 @@
 <div class="blue-border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="dictionary~Create a new branch"></strong></li>
-        <code class="shell">git branch &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git branch &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="dictionary~Move onto a branch"></strong></li>
-        <code class="shell">git checkout &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="dictionary~You can create and switch to a branch in one line"></strong></li>
-        <code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="dictionary~List the branches"></strong></li>
-        <code class="shell">git branch</code>
+        <div class='code'><code class="shell">git branch</code></div>
         <li><strong i18n-data="dictionary~Rename a branch you're currently on"></strong></li>
-        <code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></div>
     </ul>
 </div>
 
@@ -67,11 +67,11 @@
 <div class="blue-border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="dictionary~Add remote connections"></strong></li>
-        <code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
+        <div class='code'><code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></div>
         <li><strong i18n-data="dictionary~Set a URL to a remote"></strong></li>
-        <code class="shell">git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code>
+        <div class='code'><code class="shell">git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code></div>
         <li><strong i18n-data="dictionary~View remote connections"></strong></li>
-        <code class="shell">git remote -v</code>
+        <div class='code'><code class="shell">git remote -v</code></div>
     </ul>
 </div>
 
@@ -79,11 +79,11 @@
 <div class="blue-border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="dictionary~Pull in changes"></strong></li>
-        <code class="shell">git pull</code>
+        <div class='code'><code class="shell">git pull</code></div>
         <li><strong i18n-data="dictionary~Pull in changes from a remote branch"></strong></li>
-        <code class="shell">git pull &#60;REMOTENAME&#62; &#60;REMOTEBRANCH&#62;</code>
+        <div class='code'><code class="shell">git pull &#60;REMOTENAME&#62; &#60;REMOTEBRANCH&#62;</code></div>
         <li><strong i18n-data="dictionary~See changes to the remote before you pull in"></strong></li>
-        <code class="shell">git fetch --dry-run</code>
+        <div class='code'><code class="shell">git fetch --dry-run</code></div>
     </ul>
 </div>
 
@@ -91,9 +91,9 @@
 <div class="blue-border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="dictionary~Push changes"></strong></li>
-        <code class="shell">git push &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git push &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="dictionary~Merge a branch into current branch"></strong></li>
-        <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git merge &#60;BRANCHNAME&#62;</code></div>
     </ul>
 </div>
 
@@ -101,8 +101,8 @@
 <div class="blue-border-box">
     <ul class="no-list-style">
         <li><strong i18n-data="dictionary~Delete a local branch"></strong></li>
-        <code class="shell">git branch -D &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git branch -D &#60;BRANCHNAME&#62;</code></div>
         <li><strong i18n-data="dictionary~Delete a remote branch"></strong></li>
-        <code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
+        <div class='code'><code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></div>
     </ul>
 </div>

--- a/resources/layouts/challenge.hbs
+++ b/resources/layouts/challenge.hbs
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../../assets/css/new-style.css">
     <link rel="stylesheet" href="../../assets/css/new-challenge.css">
     <link rel="stylesheet" href="../../assets/css/buttons.css">
-    <style title="jsTranslationStylesheet"></style>
+    <style title="jsTranslationStylesheet" id="challenge-translation-style"></style>
   </head>
   <body>
     {{{ header }}}

--- a/resources/layouts/page.hbs
+++ b/resources/layouts/page.hbs
@@ -6,12 +6,13 @@
     <link rel="stylesheet" href="../../assets/css/new-style.css">
     <link rel="stylesheet" href="../../assets/css/new-challenge.css">
     <link rel="stylesheet" href="../../assets/css/buttons.css">
+    <style title="jsTranslationStylesheet" id="page-translation-style"></style>
   </head>
 
   <body>
     {{{ header }}}
 
-    <div class="page-wrapper">
+    <div class="page-wrapper content">
       {{{ body }}}
     </div>
 


### PR DESCRIPTION
Support rtl-languages:
- `direction: rtl` defined within appLanguages-Object
- Translation-Script now also dynamically inserts the corresponding CSS
- Code-Elements, that are always in English are kept ltr, but aligned right.

-> PR currently breaks index-page, this needs to be done separately, to include the index-page into the templates.

@akamfoad Can you have a look on here? Does this look properly? The right-align of code-elements seems proper to me, but is this typical usage for such texts in rtl? -> Currently only visible on first challenge, i'll now start to insert the divs on other challenges...