### PR TITLE
Restore language env for verification

### DIFF
--- a/lib/verify/verify-helpers.js
+++ b/lib/verify/verify-helpers.js
@@ -6,10 +6,8 @@ const { exec } = require('child_process')
 const { promisify } = require('util')
 const execPromise = promisify(exec)
 
-// Set each challenge verifying process to use
-// English language pack
-// Remained from old code... Don't know why to set this. REMOVE, if no complications appear.
-// process.env.LANG = 'C'
+// Set process to use english language (necessary for text verification)
+process.env.LANG = 'C'
 
 /*
  * Add a formatted object to given verifyList.


### PR DESCRIPTION
English language is necessary to properly interpret the git console output.
For non-english console systems, this must be set explicitly.